### PR TITLE
Various improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "insta",
  "proc-macro2",
  "syn",
+ "walkdir",
 ]
 
 [[package]]
@@ -123,6 +124,15 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -207,6 +217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +242,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+walkdir = "2"
 getopts = "0.2.21"
 proc-macro2 = { version = "1.0.39", features = ["span-locations"] }
 syn = { version = "1.0.95", features = ["full", "visit", "extra-traits"] }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ if let Ok(num) = u16::from_str(s)
 Usage:
 
 ```
-if-to-let-chain [Options] [FILE]
+if-to-let-chain [Options] [PATH]
 
 Options:
     -d, --deindent N    number of chars to deindent by (default 4)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# if-to-let-chain
+
+Converts usages of the `if_chain` macro from the
+[if-chain crate](https://docs.rs/if_chain/) to `let-chains`.
+
+Example input:
+
+```Rust
+if_chain! {
+    if let Ok(num) = u16::from_str(s);
+    if num < 4000;
+    if let Some(e) = v.get(num);
+    then {
+        println!("{e}");
+    }
+}
+```
+
+Output:
+
+```Rust
+if let Ok(num) = u16::from_str(s)
+    && num < 4000
+    && let Some(e) = v.get(num)
+{
+    println!("{e}");
+}
+```
+
+Usage:
+
+```
+if-to-let-chain [Options] [FILE]
+
+Options:
+    -d, --deindent N    number of chars to deindent by (default 4)
+    -v, --verbose       print extra information
+    -h, --help          print this help
+```
+
+### License
+[license]: #license
+
+This crate is distributed under the terms of both the MIT license
+and the Apache License (Version 2.0), at your option.
+
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
+
+#### License of your contributions
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ fn modify(contents: &mut String, deindent: usize, path: &str) -> bool {
 }
 
 fn help(opts: &Options, exit_code: i32) -> ! {
-    print!("{}", opts.usage("if-to-let-chain [Options] FILE"));
+    print!("{}", opts.usage("if-to-let-chain [Options] [FILE]"));
     process::exit(exit_code);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,13 @@ fn if_to_let_chain(input: &str, deindent: usize, path: &str) -> Option<String> {
 
     lines.remove(delete);
 
-    Some(lines.join("\n"))
+    let mut res = lines.join("\n");
+    if input.ends_with("\n") {
+        // Preserve trailing newlines (str::lines() swallows them).
+        res.push('\n');
+    }
+
+    Some(res)
 }
 
 fn modify(contents: &mut String, deindent: usize, path: &str) -> bool {


### PR DESCRIPTION
This fixes some smaller issues I encountered when using `if-to-let-chain`: 
* before it was removing newlines at the end of the file as [str:lines](https://doc.rust-lang.org/stable/std/primitive.str.html#method.lines) swallows them. Now it adds newlines but only if one was present before.
* There was no README describing the tool.
* It now automatically recurses into a directory if you pass a directory to it. This is helpful if you want to convert larger projects.